### PR TITLE
etherlab: lock version and fix library compile

### DIFF
--- a/package/etherlab/etherlab.hash
+++ b/package/etherlab/etherlab.hash
@@ -1,0 +1,2 @@
+# Locally generated
+sha256  90ad592c244651705336a22f83259ac8b67003aff019defd61aed621a9df31ba  etherlab-2698_9e65f782e8a1.tar.gz

--- a/package/etherlab/etherlab.mk
+++ b/package/etherlab/etherlab.mk
@@ -4,16 +4,13 @@
 #
 ################################################################################
 
-ETHERLAB_VERSION = stable-1.5
+ETHERLAB_VERSION = 2698:9e65f782e8a1
 ETHERLAB_SITE = http://hg.code.sf.net/p/etherlabmaster/code
 ETHERLAB_SITE_METHOD = hg
-ETHERLAB_SOURCE = etherlab-$(ETHERLAB_VERSION).tar.gz
 ETHERLAB_LICENSE = GPL-2.0 (IgH EtherCAT master), LGPL-2.1 (libraries)
 ETHERLAB_LICENSE_FILES = COPYING COPYING.LESSER
-ETHERLAB_AUTORECONF = YES
-ETHERLAB_DL_OPTS = -b $(ETHERLAB_VERSION) -r $(ETHERLAB_VERSION)
-
 ETHERLAB_INSTALL_STAGING = YES
+ETHERLAB_AUTORECONF = YES
 
 ETHERLAB_CONF_OPTS = \
 	--with-linux-dir=$(LINUX_DIR)
@@ -25,17 +22,18 @@ ETHERLAB_CONF_OPTS += $(if $(BR2_PACKAGE_ETHERLAB_E1000),--enable-e1000,--disabl
 ETHERLAB_CONF_OPTS += $(if $(BR2_PACKAGE_ETHERLAB_E1000E),--enable-e1000e,--disable-e1000e)
 ETHERLAB_CONF_OPTS += $(if $(BR2_PACKAGE_ETHERLAB_R8169),--enable-r8169,--disable-r8169)
 
-# Since we download ethercat from source control, we have to emulate
-# the bootstrap script that creates the ChangeLog file before running
-# autoreconf.  We don't want to run that script directly, since we
-# leave to the autotargets infrastructure the responsability of
-# running 'autoreconf' so that the dependencies on host-automake,
-# host-autoconf and al. are correct.
-define ETHERLAB_CREATE_CHANGELOG
+define ETHERLAB_CREATE_MISSING_FILES
 	touch $(@D)/ChangeLog
 endef
-
-ETHERLAB_POST_PATCH_HOOKS += ETHERLAB_CREATE_CHANGELOG
+ETHERLAB_POST_PATCH_HOOKS += ETHERLAB_CREATE_MISSING_FILES
 
 $(eval $(kernel-module))
+
+# The master directory is shared between the kernel module and library builds
+# so erase the .o files so that the kernel versions aren't reused.
+define ETHERLAB_KERNEL_CLEANUP
+        $(RM) $(@D)/master/*.o
+endef
+ETHERLAB_POST_BUILD_HOOKS += ETHERLAB_KERNEL_CLEANUP
+
 $(eval $(autotools-package))


### PR DESCRIPTION
This fixes a build issue where .o files compiled for the kernel were
reused in the library. This would cause vfp errors, soft/hardfloat
errors and wchar errors depending on the compiler configuration. This
was due to the Linux kernel preventing the compiler from using the
mentioned features. Since the `master` directory was shared between the
kernel and library builds, `make` would reuse .o files that it
shouldn't.

This also makes some changes to make this package submittable to
Buildroot:

1. Lock down the version. Branches aren't allowed since they may change
over time.
2. Add a .hash file to catch download corruption of strange things
happening with the source code.
3. Align the ChangeLog creation to how other Buildroot packages do it.
Unfortunately, this removes a nice comment, but the Buildroot devs like
consistency and this makes it consistent.